### PR TITLE
Add Multi-Network-Support

### DIFF
--- a/MULTI_NETWORK.md
+++ b/MULTI_NETWORK.md
@@ -1,0 +1,343 @@
+# Multi-Network Support Guide
+
+WiFi Auto Auth now supports multiple network profiles, allowing you to automatically connect to different WiFi networks (home, work, school, etc.) with different credentials and settings.
+
+## Features
+
+- **Auto-Detection**: Automatically detects current network SSID and selects appropriate profile
+- **Manual Selection**: Override auto-detection by specifying a network profile
+- **Network-Specific Logging**: Track login attempts per network
+- **Dashboard Integration**: View network-specific statistics in the web dashboard
+- **Backward Compatibility**: Existing single-network configurations continue to work
+
+## Configuration
+
+### New Multi-Network Format
+
+Create or update your `config.json` file with the new multi-network format:
+
+```json
+{
+  "default_network": "home",
+  "networks": {
+    "home": {
+      "ssid": "HomeWiFi",
+      "wifi_url": "http://192.168.1.1/login",
+      "username": "your_home_username",
+      "password": "your_home_password",
+      "product_type": "router",
+      "description": "Home WiFi network"
+    },
+    "work": {
+      "ssid": "OfficeWiFi",
+      "wifi_url": "http://10.0.0.1/login",
+      "username": "your_work_username",
+      "password": "your_work_password",
+      "product_type": "enterprise",
+      "description": "Work WiFi network"
+    },
+    "school": {
+      "ssid": "SchoolWiFi",
+      "wifi_url": "http://172.16.1.1/login",
+      "username": "your_school_username",
+      "password": "your_school_password",
+      "product_type": "edu",
+      "description": "School WiFi network"
+    }
+  },
+  "dashboard": {
+    "host": "127.0.0.1",
+    "port": 8000,
+    "username": "admin",
+    "password": "admin123"
+  }
+}
+```
+
+### Legacy Configuration Support
+
+Existing single-network configurations will continue to work:
+
+```json
+{
+  "wifi_url": "http://192.168.1.1/login",
+  "username": "your_username",
+  "password": "your_password",
+  "product_type": "router"
+}
+```
+
+## Usage
+
+### Auto-Detection (Recommended)
+
+The script automatically detects your current network SSID and selects the appropriate profile:
+
+```bash
+# Auto-detect current network and login
+python wifi_auto_login.py --login
+
+# Auto-detect and show recent logs
+python wifi_auto_login.py
+```
+
+### Manual Network Selection
+
+Override auto-detection by specifying a network profile:
+
+```bash
+# Login using specific network profile
+python wifi_auto_login.py --login --network work
+
+# Test connection for specific network
+python wifi_auto_login.py --test --network home
+```
+
+### Network Management Commands
+
+```bash
+# List all configured network profiles
+python wifi_auto_login.py --list-networks
+
+# Detect current network and show matching profile
+python wifi_auto_login.py --detect-network
+
+# View logs for specific network
+python wifi_auto_login.py --view-logs 10 --network-filter work
+```
+
+## Command Reference
+
+### New Commands
+
+| Command | Description |
+|---------|-------------|
+| `--network PROFILE` | Use specific network profile |
+| `--list-networks` | List all configured networks |
+| `--detect-network` | Detect current network |
+| `--network-filter PROFILE` | Filter logs by network |
+
+### Updated Commands
+
+| Command | Description |
+|---------|-------------|
+| `--login` | Auto-detects network or uses --network |
+| `--test` | Tests connection for detected/specified network |
+| `--view-logs N` | Shows network info in logs |
+
+## Network Detection
+
+The script uses platform-specific methods to detect your current WiFi network:
+
+### Windows
+- Uses `netsh wlan show interfaces` command
+- Requires WiFi adapter to be connected
+
+### macOS  
+- Uses `networksetup -getairportnetwork en0` command
+- Falls back to `airport -I` utility
+
+### Linux
+- Tries multiple methods: `iwgetid`, `nmcli`, `iwconfig`
+- Requires appropriate network utilities installed
+
+## Database Schema
+
+The database now includes network information:
+
+```sql
+CREATE TABLE login_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT,
+    network_name TEXT,        -- New: Network profile name
+    network_ssid TEXT,        -- New: Actual SSID
+    username TEXT,
+    password TEXT,
+    a TEXT,
+    response_status TEXT,
+    response_message TEXT
+);
+```
+
+Existing databases are automatically upgraded with new columns.
+
+## Dashboard Features
+
+### Network Statistics
+- Per-network success rates
+- Network-specific attempt counts
+- Last login time per network
+
+### Filtering
+- Filter logs by network profile
+- Network-specific historical data
+- Multi-network overview
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/network-stats` | Get per-network statistics |
+| `/api/attempts?network_filter=PROFILE` | Filtered login attempts |
+
+## Migration Guide
+
+### From Single Network to Multi-Network
+
+1. **Backup your current config.json**:
+   ```bash
+   cp config.json config.json.backup
+   ```
+
+2. **Update configuration format**:
+   ```bash
+   # Use the new example as template
+   cp config.example.json config.json
+   # Edit config.json with your networks
+   ```
+
+3. **Test the configuration**:
+   ```bash
+   python wifi_auto_login.py --list-networks
+   python wifi_auto_login.py --detect-network
+   ```
+
+### Gradual Migration
+
+You can keep using legacy format while adding new networks:
+
+```json
+{
+  "wifi_url": "http://192.168.1.1/login",
+  "username": "legacy_user",
+  "password": "legacy_pass",
+  "networks": {
+    "work": {
+      "ssid": "OfficeWiFi",
+      "wifi_url": "http://10.0.0.1/login",
+      "username": "work_user",
+      "password": "work_pass"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Network Detection Issues
+
+1. **No SSID detected**:
+   ```bash
+   # Check if WiFi is connected
+   python wifi_auto_login.py --detect-network
+   
+   # Manually specify network
+   python wifi_auto_login.py --login --network home
+   ```
+
+2. **Platform not supported**:
+   - Windows: Ensure you have admin privileges for netsh
+   - macOS: Check if networksetup is available
+   - Linux: Install wireless-tools or network-manager
+
+3. **Profile not found**:
+   ```bash
+   # List available profiles
+   python wifi_auto_login.py --list-networks
+   
+   # Check SSID matches exactly
+   python wifi_auto_login.py --detect-network
+   ```
+
+### Configuration Issues
+
+1. **Invalid JSON**:
+   ```bash
+   # Validate JSON syntax
+   python -m json.tool config.json
+   ```
+
+2. **Missing network profile**:
+   - Add the network to your config.json
+   - Ensure SSID matches exactly (case-sensitive)
+
+3. **Legacy compatibility**:
+   - Old format still works
+   - Gradually migrate to new format
+
+## Best Practices
+
+### Network Profile Design
+
+1. **Use descriptive names**: `home`, `work`, `coffee-shop`
+2. **Include descriptions**: Help identify networks later
+3. **Set default network**: For fallback when detection fails
+4. **Test each profile**: Verify credentials before deployment
+
+### Security Considerations
+
+1. **Protect config.json**: Contains passwords in plain text
+2. **Use different passwords**: Don't reuse across networks
+3. **Regular updates**: Change passwords periodically
+4. **Backup configurations**: Keep secure backups
+
+### Monitoring
+
+1. **Use dashboard**: Monitor per-network success rates
+2. **Check logs regularly**: Identify authentication issues
+3. **Network-specific analysis**: Filter logs by network
+4. **Set up alerts**: Monitor for failure patterns
+
+## Examples
+
+### Complete Multi-Network Setup
+
+```bash
+# 1. Set up configuration
+cp config.example.json config.json
+# Edit config.json with your networks
+
+# 2. Test configuration
+python wifi_auto_login.py --list-networks
+python wifi_auto_login.py --detect-network
+
+# 3. Test each network
+python wifi_auto_login.py --test --network home
+python wifi_auto_login.py --test --network work
+
+# 4. Set up automatic login
+python wifi_auto_login.py --login
+
+# 5. Monitor via dashboard
+python wifi_auto_login.py --dashboard
+```
+
+### Automated Network Switching
+
+```bash
+#!/bin/bash
+# Example script for automated network handling
+
+# Detect current network
+CURRENT_NETWORK=$(python wifi_auto_login.py --detect-network 2>/dev/null | grep "Found matching profile" | cut -d: -f2 | xargs)
+
+if [ -n "$CURRENT_NETWORK" ]; then
+    echo "Logging into detected network: $CURRENT_NETWORK"
+    python wifi_auto_login.py --login --network "$CURRENT_NETWORK"
+else
+    echo "No matching network profile found, using auto-detection"
+    python wifi_auto_login.py --login
+fi
+```
+
+## Support
+
+If you encounter issues with multi-network support:
+
+1. Check the troubleshooting section above
+2. Enable debug logging: `python wifi_auto_login.py --log-level DEBUG`
+3. Test with single network first
+4. Report issues with network detection details
+5. Include platform information (Windows/macOS/Linux)
+
+The multi-network feature is designed to be backward compatible while providing powerful new capabilities for managing multiple WiFi environments.

--- a/network_utils.py
+++ b/network_utils.py
@@ -1,0 +1,300 @@
+"""
+Network utilities for WiFi Auto Auth - Multi-Network Support
+Handles network detection, SSID identification, and network profile management.
+"""
+
+import subprocess
+import platform
+import re
+import json
+import os
+from typing import Optional, Dict, List, Tuple
+from config.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+class NetworkDetector:
+    """Handles network detection and SSID identification across different platforms."""
+    
+    def __init__(self):
+        self.platform = platform.system().lower()
+        logger.debug(f"Initialized NetworkDetector for platform: {self.platform}")
+    
+    def get_current_ssid(self) -> Optional[str]:
+        """
+        Get the SSID of the currently connected WiFi network.
+        
+        Returns:
+            str: SSID of current network, or None if not connected to WiFi
+        """
+        try:
+            if self.platform == "windows":
+                return self._get_ssid_windows()
+            elif self.platform == "darwin":  # macOS
+                return self._get_ssid_macos()
+            elif self.platform == "linux":
+                return self._get_ssid_linux()
+            else:
+                logger.warning(f"Unsupported platform: {self.platform}")
+                return None
+        except Exception as e:
+            logger.error(f"Failed to get current SSID: {e}")
+            return None
+    
+    def _get_ssid_windows(self) -> Optional[str]:
+        """Get SSID on Windows using netsh command."""
+        try:
+            # Use netsh to get WiFi profile information
+            cmd = ["netsh", "wlan", "show", "profiles"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            
+            # Get the currently connected profile
+            cmd_interfaces = ["netsh", "wlan", "show", "interfaces"]
+            interfaces_result = subprocess.run(cmd_interfaces, capture_output=True, text=True, check=True)
+            
+            # Parse the SSID from the interfaces output
+            for line in interfaces_result.stdout.split('\n'):
+                if 'SSID' in line and 'BSSID' not in line:
+                    # Extract SSID (format: "    SSID                   : NetworkName")
+                    match = re.search(r'SSID\s*:\s*(.+)', line.strip())
+                    if match:
+                        ssid = match.group(1).strip()
+                        logger.debug(f"Detected Windows SSID: {ssid}")
+                        return ssid
+            
+            logger.debug("No active WiFi connection found on Windows")
+            return None
+            
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Windows netsh command failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Error getting Windows SSID: {e}")
+            return None
+    
+    def _get_ssid_macos(self) -> Optional[str]:
+        """Get SSID on macOS using airport utility."""
+        try:
+            # Try using networksetup first
+            cmd = ["networksetup", "-getairportnetwork", "en0"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            
+            # Parse output (format: "Current Wi-Fi Network: NetworkName")
+            if "Current Wi-Fi Network:" in result.stdout:
+                ssid = result.stdout.split("Current Wi-Fi Network:")[-1].strip()
+                if ssid and ssid != "You are not associated with an AirPort network.":
+                    logger.debug(f"Detected macOS SSID: {ssid}")
+                    return ssid
+            
+            # Fallback to airport utility
+            airport_cmd = ["/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport", "-I"]
+            airport_result = subprocess.run(airport_cmd, capture_output=True, text=True, check=True)
+            
+            for line in airport_result.stdout.split('\n'):
+                if 'SSID:' in line:
+                    ssid = line.split('SSID:')[-1].strip()
+                    logger.debug(f"Detected macOS SSID via airport: {ssid}")
+                    return ssid
+            
+            logger.debug("No active WiFi connection found on macOS")
+            return None
+            
+        except subprocess.CalledProcessError as e:
+            logger.error(f"macOS network command failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Error getting macOS SSID: {e}")
+            return None
+    
+    def _get_ssid_linux(self) -> Optional[str]:
+        """Get SSID on Linux using various methods."""
+        methods = [
+            self._linux_iwgetid,
+            self._linux_nmcli,
+            self._linux_iwconfig
+        ]
+        
+        for method in methods:
+            try:
+                ssid = method()
+                if ssid:
+                    logger.debug(f"Detected Linux SSID: {ssid}")
+                    return ssid
+            except Exception as e:
+                logger.debug(f"Linux method {method.__name__} failed: {e}")
+                continue
+        
+        logger.debug("No active WiFi connection found on Linux")
+        return None
+    
+    def _linux_iwgetid(self) -> Optional[str]:
+        """Get SSID using iwgetid command."""
+        cmd = ["iwgetid", "-r"]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        ssid = result.stdout.strip()
+        return ssid if ssid else None
+    
+    def _linux_nmcli(self) -> Optional[str]:
+        """Get SSID using NetworkManager's nmcli."""
+        cmd = ["nmcli", "-t", "-f", "active,ssid", "dev", "wifi"]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        
+        for line in result.stdout.split('\n'):
+            if line.startswith('yes:'):
+                ssid = line.split(':', 1)[1]
+                return ssid if ssid else None
+        return None
+    
+    def _linux_iwconfig(self) -> Optional[str]:
+        """Get SSID using iwconfig command."""
+        cmd = ["iwconfig"]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        
+        for line in result.stdout.split('\n'):
+            if 'ESSID:' in line:
+                match = re.search(r'ESSID:"([^"]*)"', line)
+                if match:
+                    return match.group(1)
+        return None
+
+
+class NetworkProfileManager:
+    """Manages network profiles and configuration loading."""
+    
+    def __init__(self, config_path: str = "config.json"):
+        self.config_path = config_path
+        self.detector = NetworkDetector()
+        logger.debug(f"Initialized NetworkProfileManager with config: {config_path}")
+    
+    def load_config(self) -> Dict:
+        """Load and parse configuration file."""
+        if not os.path.exists(self.config_path):
+            raise FileNotFoundError(
+                f"Missing {self.config_path}. Please copy config.example.json to {self.config_path} and configure your networks."
+            )
+        
+        with open(self.config_path, "r") as f:
+            config = json.load(f)
+        
+        logger.debug(f"Loaded configuration from {self.config_path}")
+        return config
+    
+    def get_available_networks(self) -> List[str]:
+        """Get list of configured network profile names."""
+        try:
+            config = self.load_config()
+            
+            # Handle both new multi-network format and legacy format
+            if "networks" in config:
+                networks = list(config["networks"].keys())
+                logger.debug(f"Found configured networks: {networks}")
+                return networks
+            else:
+                # Legacy single network configuration
+                logger.debug("Using legacy single network configuration")
+                return ["default"]
+        except Exception as e:
+            logger.error(f"Error getting available networks: {e}")
+            return []
+    
+    def get_network_profile(self, network_name: Optional[str] = None, auto_detect: bool = True) -> Tuple[str, Dict]:
+        """
+        Get network configuration for specified network or auto-detect current network.
+        
+        Args:
+            network_name: Specific network profile to use
+            auto_detect: Whether to auto-detect current network if network_name is None
+            
+        Returns:
+            Tuple of (network_name, network_config)
+        """
+        config = self.load_config()
+        
+        # Handle legacy configuration format
+        if "networks" not in config:
+            logger.info("Using legacy configuration format")
+            legacy_config = {
+                "ssid": config.get("ssid", "Unknown"),
+                "wifi_url": config["wifi_url"],
+                "username": config["username"],
+                "password": config["password"],
+                "product_type": config.get("product_type", "0"),
+                "description": "Legacy configuration"
+            }
+            return "legacy", legacy_config
+        
+        networks = config["networks"]
+        
+        # If specific network requested, use it
+        if network_name:
+            if network_name in networks:
+                logger.info(f"Using specified network profile: {network_name}")
+                return network_name, networks[network_name]
+            else:
+                raise ValueError(f"Network profile '{network_name}' not found in configuration")
+        
+        # Auto-detect current network
+        if auto_detect:
+            current_ssid = self.detector.get_current_ssid()
+            if current_ssid:
+                logger.info(f"Detected current SSID: {current_ssid}")
+                
+                # Find matching network profile by SSID
+                for profile_name, profile_config in networks.items():
+                    if profile_config.get("ssid") == current_ssid:
+                        logger.info(f"Found matching network profile: {profile_name}")
+                        return profile_name, profile_config
+                
+                logger.warning(f"No network profile found for SSID: {current_ssid}")
+            else:
+                logger.warning("Could not detect current network SSID")
+        
+        # Fall back to default network
+        default_network = config.get("default_network", list(networks.keys())[0])
+        if default_network in networks:
+            logger.info(f"Using default network profile: {default_network}")
+            return default_network, networks[default_network]
+        
+        # If default not found, use first available
+        first_network = list(networks.keys())[0]
+        logger.info(f"Using first available network profile: {first_network}")
+        return first_network, networks[first_network]
+    
+    def list_networks(self) -> Dict[str, Dict]:
+        """Get detailed information about all configured networks."""
+        try:
+            config = self.load_config()
+            
+            if "networks" not in config:
+                # Legacy format
+                return {
+                    "legacy": {
+                        "ssid": config.get("ssid", "Unknown"),
+                        "wifi_url": config["wifi_url"],
+                        "description": "Legacy configuration"
+                    }
+                }
+            
+            return config["networks"]
+        except Exception as e:
+            logger.error(f"Error listing networks: {e}")
+            return {}
+
+
+# Convenience functions for backward compatibility
+def get_current_ssid() -> Optional[str]:
+    """Get the SSID of the currently connected WiFi network."""
+    detector = NetworkDetector()
+    return detector.get_current_ssid()
+
+
+def get_network_profile(network_name: Optional[str] = None, auto_detect: bool = True) -> Tuple[str, Dict]:
+    """Get network configuration for specified network or auto-detect current network."""
+    manager = NetworkProfileManager()
+    return manager.get_network_profile(network_name, auto_detect)
+
+
+def list_available_networks() -> List[str]:
+    """Get list of configured network profile names."""
+    manager = NetworkProfileManager()
+    return manager.get_available_networks()

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,38 @@ python wifi_auto_login.py --dashboard
 
 **📖 Full documentation: [DASHBOARD.md](DASHBOARD.md)**
 
+## **🌐 NEW: Multi-Network Support**
+
+**Automatically handle multiple WiFi networks with intelligent auto-detection!**
+
+### **Multi-Network Features**
+- 🏠 **Multiple Profiles**: Configure home, work, school networks
+- 🔍 **Auto-Detection**: Automatically detects current SSID
+- 📱 **Smart Selection**: Chooses appropriate credentials
+- 📊 **Network Analytics**: Per-network statistics in dashboard
+- 🔄 **Seamless Switching**: No manual intervention needed
+- 📋 **Easy Management**: List, detect, and filter by network
+
+### **Quick Multi-Network Setup**
+```bash
+# Copy and configure multi-network template
+cp config.example.json config.json
+
+# List configured networks
+python wifi_auto_login.py --list-networks
+
+# Auto-detect current network
+python wifi_auto_login.py --detect-network
+
+# Login with auto-detection
+python wifi_auto_login.py --login
+
+# Use specific network profile
+python wifi_auto_login.py --login --network work
+```
+
+**📖 Complete guide: [MULTI_NETWORK.md](MULTI_NETWORK.md)**
+
 ## **Logging Options**
 
 This application features a comprehensive professional logging system that provides detailed insights into login attempts, debugging information, and system status. The logging system supports multiple output destinations, configurable log levels, and automatic log rotation.

--- a/wifi_auto_login.py
+++ b/wifi_auto_login.py
@@ -22,6 +22,20 @@ def load_config():
     
     return config
 
+# Initialize logging first
+from config.logging_config import setup_logging_from_env, get_logger
+setup_logging_from_env()
+logger = get_logger(__name__)
+
+# Import network utilities for multi-network support
+try:
+    from network_utils import NetworkProfileManager, get_current_ssid
+    MULTI_NETWORK_SUPPORT = True
+    logger.info("Multi-network support enabled")
+except ImportError as e:
+    logger.warning(f"Multi-network support disabled: {e}")
+    MULTI_NETWORK_SUPPORT = False
+
 # Global variables - will be loaded when needed
 URL = None
 USERNAME = None
@@ -31,37 +45,51 @@ PRODUCT_TYPE = None
 # --- DATABASE SETUP ---
 DB_NAME = "wifi_log.db"
 
-# Initialize logging
-from config.logging_config import setup_logging_from_env, get_logger
-setup_logging_from_env()
-logger = get_logger(__name__)
-
 def setup_database():
     """Create the database and table if they do not exist."""
     conn = sqlite3.connect(DB_NAME)
     cursor = conn.cursor()
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS login_attempts (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT,
-            username TEXT,
-            password TEXT,
-            a TEXT,
-            response_status TEXT,
-            response_message TEXT
-        )
-    """)
+    
+    # Check if the table exists and get its schema
+    cursor.execute("PRAGMA table_info(login_attempts)")
+    columns = [row[1] for row in cursor.fetchall()]
+    
+    if not columns:
+        # Create new table with network support
+        cursor.execute("""
+            CREATE TABLE login_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                network_name TEXT,
+                network_ssid TEXT,
+                username TEXT,
+                password TEXT,
+                a TEXT,
+                response_status TEXT,
+                response_message TEXT
+            )
+        """)
+        logger.info("Created new login_attempts table with network support")
+    else:
+        # Check if we need to add network columns to existing table
+        if 'network_name' not in columns:
+            cursor.execute("ALTER TABLE login_attempts ADD COLUMN network_name TEXT")
+            logger.info("Added network_name column to existing table")
+        
+        if 'network_ssid' not in columns:
+            cursor.execute("ALTER TABLE login_attempts ADD COLUMN network_ssid TEXT")
+            logger.info("Added network_ssid column to existing table")
     conn.commit()
     conn.close()
 
-def log_attempt(username, password, a, response_status, response_message):
+def log_attempt(username, password, a, response_status, response_message, network_name=None, network_ssid=None):
     """Log each login attempt in the database."""
     conn = sqlite3.connect(DB_NAME)
     cursor = conn.cursor()
     cursor.execute("""
-        INSERT INTO login_attempts (timestamp, username, password, a, response_status, response_message)
-        VALUES (?, ?, ?, ?, ?, ?)
-    """, (datetime.datetime.now(), username, "******", a, response_status, response_message))
+        INSERT INTO login_attempts (timestamp, network_name, network_ssid, username, password, a, response_status, response_message)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """, (datetime.datetime.now(), network_name, network_ssid, username, "******", a, response_status, response_message))
     conn.commit()
     conn.close()
 
@@ -72,15 +100,40 @@ def extract_message(response_text):
     return match.group(1) if match else "Unknown response"
 
 # --- MAIN WIFI LOGIN FUNCTION ---
-def wifi_login():
+def wifi_login(network_name=None):
     """Perform the WiFi login request and log the result."""
-    # Load config when needed
-    config = load_config()
-    global URL, USERNAME, PASSWORD, PRODUCT_TYPE
-    URL = config["wifi_url"]
-    USERNAME = config["username"]
-    PASSWORD = config["password"]
-    PRODUCT_TYPE = config.get("product_type", "0")
+    network_profile_name = "legacy"
+    network_ssid = "Unknown"
+    
+    try:
+        if MULTI_NETWORK_SUPPORT:
+            # Use multi-network configuration
+            manager = NetworkProfileManager()
+            network_profile_name, network_config = manager.get_network_profile(network_name, auto_detect=True)
+            network_ssid = network_config.get("ssid", "Unknown")
+            
+            URL = network_config["wifi_url"]
+            USERNAME = network_config["username"]
+            PASSWORD = network_config["password"]
+            PRODUCT_TYPE = network_config.get("product_type", "0")
+            
+            print(f"\n🌐 Using Network Profile: {network_profile_name}")
+            print(f"📡 Network SSID: {network_ssid}")
+            print(f"🔗 Login URL: {URL}")
+        else:
+            # Fallback to legacy single network configuration
+            config = load_config()
+            URL = config["wifi_url"]
+            USERNAME = config["username"]
+            PASSWORD = config["password"]
+            PRODUCT_TYPE = config.get("product_type", "0")
+            network_ssid = config.get("ssid", "Unknown")
+            print(f"\n🌐 Using Legacy Configuration")
+    
+    except Exception as e:
+        logger.error(f"Configuration error: {e}")
+        print(f"❌ Configuration Error: {e}")
+        return
     
     a_value = str(int(datetime.datetime.now().timestamp()))  # Generate dynamic 'a' value
 
@@ -105,42 +158,74 @@ def wifi_login():
         print(f"Message: {response_message}")
         print("-" * 80)
 
-        # Log the attempt in SQLite
-        log_attempt(USERNAME, PASSWORD, a_value, response_status, response_message)
+        # Log the attempt in SQLite with network information
+        log_attempt(USERNAME, PASSWORD, a_value, response_status, response_message, 
+                   network_profile_name, network_ssid)
 
     except requests.exceptions.RequestException as e:
         print(f"❌ Error: {e}")
-        log_attempt(USERNAME, PASSWORD, a_value, "FAILED", str(e))
+        log_attempt(USERNAME, PASSWORD, a_value, "FAILED", str(e), 
+                   network_profile_name, network_ssid)
 
 # --- VIEW LOGIN LOGS ---
-def view_logs(limit=5):
+def view_logs(limit=5, network_filter=None):
     """Display login logs in a readable format."""
     conn = sqlite3.connect(DB_NAME)
     cursor = conn.cursor()
-    cursor.execute("""
-        SELECT timestamp, username, a, response_status, response_message 
-        FROM login_attempts 
-        ORDER BY timestamp DESC 
-        LIMIT ?
-    """, (limit,))
+    
+    # Check if table has new network columns
+    cursor.execute("PRAGMA table_info(login_attempts)")
+    columns = [row[1] for row in cursor.fetchall()]
+    has_network_columns = 'network_name' in columns and 'network_ssid' in columns
+    
+    if has_network_columns:
+        base_query = """
+            SELECT timestamp, network_name, network_ssid, username, a, response_status, response_message 
+            FROM login_attempts 
+        """
+        if network_filter:
+            query = base_query + "WHERE network_name = ? ORDER BY timestamp DESC LIMIT ?"
+            cursor.execute(query, (network_filter, limit))
+        else:
+            query = base_query + "ORDER BY timestamp DESC LIMIT ?"
+            cursor.execute(query, (limit,))
+    else:
+        # Legacy table structure
+        cursor.execute("""
+            SELECT timestamp, username, a, response_status, response_message 
+            FROM login_attempts 
+            ORDER BY timestamp DESC 
+            LIMIT ?
+        """, (limit,))
 
     logs = cursor.fetchall()
     conn.close()
 
     if not logs:
-        logger.info("No login attempts found in database")
+        filter_msg = f" for network '{network_filter}'" if network_filter else ""
+        logger.info(f"No login attempts found in database{filter_msg}")
         return
 
-    logger.info("Recent login attempts retrieved from database")
+    filter_msg = f" for network '{network_filter}'" if network_filter else ""
+    logger.info(f"Recent login attempts retrieved from database{filter_msg}")
     logger.info("=" * 80)
 
     for log in logs:
-        timestamp, username, a, status, message = log
-        logger.info(f"Time: {timestamp}")
-        logger.info(f"Username: {username}")
-        logger.info(f"Session ID (a): {a}")
-        logger.info(f"Status: {status}")
-        logger.info(f"Message: {message}")
+        if has_network_columns:
+            timestamp, network_name, network_ssid, username, a, status, message = log
+            logger.info(f"Time: {timestamp}")
+            logger.info(f"Network: {network_name} ({network_ssid})")
+            logger.info(f"Username: {username}")
+            logger.info(f"Session ID (a): {a}")
+            logger.info(f"Status: {status}")
+            logger.info(f"Message: {message}")
+        else:
+            timestamp, username, a, status, message = log
+            logger.info(f"Time: {timestamp}")
+            logger.info(f"Username: {username}")
+            logger.info(f"Session ID (a): {a}")
+            logger.info(f"Status: {status}")
+            logger.info(f"Message: {message}")
         logger.info("-" * 80)
 
 def parse_arguments():
@@ -209,12 +294,19 @@ def clear_logs():
     conn.close()
     print("✅ All logs have been cleared.")
 
-def test_connection():
+def test_connection(network_name=None):
     """Tests if the login URL is reachable."""
-    config = load_config()
-    url = config["wifi_url"]
-    print(f"🔗 Testing connection to {url}...")
     try:
+        if MULTI_NETWORK_SUPPORT:
+            manager = NetworkProfileManager()
+            network_profile_name, network_config = manager.get_network_profile(network_name, auto_detect=True)
+            url = network_config["wifi_url"]
+            print(f"🔗 Testing connection for network '{network_profile_name}' to {url}...")
+        else:
+            config = load_config()
+            url = config["wifi_url"]
+            print(f"🔗 Testing connection to {url}...")
+        
         response = requests.head(url, timeout=5) # Use HEAD to be efficient
         if response.status_code == 200:
             print(f"✅ Connection successful! The server responded with status {response.status_code}.")
@@ -222,17 +314,188 @@ def test_connection():
             print(f"⚠️ Connection successful, but the server responded with status {response.status_code}.")
     except requests.exceptions.RequestException as e:
         print(f"❌ Connection failed: {e}")
+    except Exception as e:
+        print(f"❌ Configuration error: {e}")
 
 def run_setup_wizard():
     """Guides the user through an interactive setup process."""
     print("--- WiFi-Auto-Auth Interactive Setup ---")
     print("This wizard will help you configure the script.")
+    print()
+    
+    # Ask about multi-network setup
+    print("Choose configuration type:")
+    print("1. Single Network (Legacy)")
+    print("2. Multi-Network (Recommended)")
+    
+    choice = input("\nEnter your choice (1 or 2): ").strip()
+    
+    if choice == "2":
+        setup_multi_network()
+    else:
+        setup_single_network()
+
+def setup_single_network():
+    """Set up single network configuration."""
+    print("\n--- Single Network Setup ---")
     
     url = input("1. Enter the POST request URL from your network's login page: ")
     username = input("2. Enter your login username: ")
     password = input("3. Enter your login password: ")
+    product_type = input("4. Enter product type (optional, press Enter for default): ") or "0"
+    
+    config = {
+        "wifi_url": url,
+        "username": username,
+        "password": password,
+        "product_type": product_type,
+        "dashboard": {
+            "host": "127.0.0.1",
+            "port": 8000,
+            "username": "admin",
+            "password": "admin123"
+        }
+    }
+    
+    save_config(config)
+    print("\n✅ Single network setup complete!")
 
-    print("\nSetup Complete!")
+def setup_multi_network():
+    """Set up multi-network configuration."""
+    print("\n--- Multi-Network Setup ---")
+    
+    networks = {}
+    default_network = None
+    
+    while True:
+        print(f"\n--- Network Profile #{len(networks) + 1} ---")
+        
+        profile_name = input("Enter network profile name (e.g., home, work, school): ").strip()
+        if not profile_name:
+            break
+            
+        ssid = input(f"Enter SSID for {profile_name}: ").strip()
+        url = input(f"Enter login URL for {profile_name}: ").strip()
+        username = input(f"Enter username for {profile_name}: ").strip()
+        password = input(f"Enter password for {profile_name}: ").strip()
+        product_type = input(f"Enter product type for {profile_name} (optional): ").strip() or "0"
+        description = input(f"Enter description for {profile_name} (optional): ").strip() or f"{profile_name.title()} network"
+        
+        networks[profile_name] = {
+            "ssid": ssid,
+            "wifi_url": url,
+            "username": username,
+            "password": password,
+            "product_type": product_type,
+            "description": description
+        }
+        
+        if not default_network:
+            default_network = profile_name
+        
+        add_more = input(f"\nAdd another network profile? (y/N): ").strip().lower()
+        if add_more not in ['y', 'yes']:
+            break
+    
+    if not networks:
+        print("No networks configured. Falling back to single network setup.")
+        setup_single_network()
+        return
+    
+    # Ask for default network
+    if len(networks) > 1:
+        print(f"\nAvailable networks: {', '.join(networks.keys())}")
+        default_choice = input(f"Enter default network (press Enter for '{default_network}'): ").strip()
+        if default_choice in networks:
+            default_network = default_choice
+    
+    config = {
+        "default_network": default_network,
+        "networks": networks,
+        "dashboard": {
+            "host": "127.0.0.1",
+            "port": 8000,
+            "username": "admin",
+            "password": "admin123"
+        }
+    }
+    
+    save_config(config)
+    print(f"\n✅ Multi-network setup complete! {len(networks)} networks configured.")
+    print(f"Default network: {default_network}")
+
+def save_config(config):
+    """Save configuration to config.json file."""
+    try:
+        with open(CONFIG_PATH, 'w') as f:
+            json.dump(config, f, indent=2)
+        print(f"\n💾 Configuration saved to {CONFIG_PATH}")
+    except Exception as e:
+        print(f"\n❌ Error saving configuration: {e}")
+
+def list_networks():
+    """List all configured network profiles."""
+    if not MULTI_NETWORK_SUPPORT:
+        print("❌ Multi-network support not available. Using legacy configuration.")
+        return
+    
+    try:
+        manager = NetworkProfileManager()
+        networks = manager.list_networks()
+        current_ssid = get_current_ssid()
+        
+        print("\n📶 Configured Network Profiles:")
+        print("=" * 60)
+        
+        for name, config in networks.items():
+            ssid = config.get("ssid", "Unknown")
+            url = config.get("wifi_url", "Unknown")
+            description = config.get("description", "No description")
+            
+            # Mark current network
+            current_marker = " 📍 CURRENT" if ssid == current_ssid else ""
+            
+            print(f"🌐 Network: {name}{current_marker}")
+            print(f"   SSID: {ssid}")
+            print(f"   URL: {url}")
+            print(f"   Description: {description}")
+            print("-" * 60)
+            
+        if current_ssid:
+            print(f"\n📡 Currently connected to: {current_ssid}")
+        else:
+            print("\n📡 No WiFi connection detected")
+            
+    except Exception as e:
+        print(f"❌ Error listing networks: {e}")
+
+def detect_network():
+    """Detect current network and show matching profile."""
+    if not MULTI_NETWORK_SUPPORT:
+        print("❌ Multi-network support not available.")
+        return
+    
+    try:
+        current_ssid = get_current_ssid()
+        
+        if not current_ssid:
+            print("📡 No WiFi connection detected")
+            return
+        
+        print(f"📡 Current SSID: {current_ssid}")
+        
+        manager = NetworkProfileManager()
+        try:
+            network_name, network_config = manager.get_network_profile(auto_detect=True)
+            print(f"✅ Found matching profile: {network_name}")
+            print(f"   Description: {network_config.get('description', 'No description')}")
+            print(f"   Login URL: {network_config.get('wifi_url', 'Unknown')}")
+        except Exception:
+            print("⚠️ No matching network profile found")
+            print("💡 You may need to add this network to your config.json")
+            
+    except Exception as e:
+        print(f"❌ Error detecting network: {e}")
 
 def start_dashboard():
     """Start the web dashboard server."""
@@ -257,7 +520,7 @@ def start_dashboard():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="A script to automatically log into captive portal WiFi networks."
+        description="A script to automatically log into captive portal WiFi networks with multi-network support."
     )
     
     parser.add_argument(
@@ -266,12 +529,34 @@ if __name__ == "__main__":
         help="Perform a login attempt."
     )
     parser.add_argument(
+        '--network', '-n',
+        type=str,
+        metavar='PROFILE',
+        help="Specify which network profile to use (overrides auto-detection)."
+    )
+    parser.add_argument(
         '--view-logs', 
         nargs='?', 
         const=5, 
         type=int, 
         metavar='N', 
         help="View the last N login attempts. Defaults to 5 if no number is provided."
+    )
+    parser.add_argument(
+        '--network-filter',
+        type=str,
+        metavar='PROFILE',
+        help="Filter logs by network profile name."
+    )
+    parser.add_argument(
+        '--list-networks',
+        action='store_true',
+        help="List all configured network profiles."
+    )
+    parser.add_argument(
+        '--detect-network',
+        action='store_true',
+        help="Detect current network and show matching profile."
     )
     parser.add_argument(
         '--setup', 
@@ -301,23 +586,27 @@ if __name__ == "__main__":
         run_setup_wizard()
     elif args.dashboard:
         start_dashboard()
+    elif args.list_networks:
+        list_networks()
+    elif args.detect_network:
+        detect_network()
     else:
         # For operations that need database/config
         try:
             setup_database()  # Ensure the database is always set up
             
             if args.login:
-                wifi_login()
+                wifi_login(args.network)
             elif args.view_logs is not None:
-                view_logs(args.view_logs)
+                view_logs(args.view_logs, args.network_filter)
             elif args.test:
-                test_connection()
+                test_connection(args.network)
             elif args.clear_logs:
                 clear_logs()
             else:
                 print("No arguments provided. Performing default login action.")
-                wifi_login()
-                view_logs(1)
+                wifi_login(args.network)
+                view_logs(1, args.network_filter)
                 
         except FileNotFoundError as e:
             print(f"❌ Configuration Error: {e}")


### PR DESCRIPTION
### Summary  
- Adds support for multiple WiFi network profiles with auto-detection and smart credential selection.  
- Fully backward compatible with existing single-network configurations.  

### What’s Included  
- **Config**: New format with multiple profiles (e.g., home/work/school).  
- **Cross-Platform**: SSID detection for Windows, macOS, and Linux.  
- **CLI**:  
  - `--network`  
  - `--list-networks`  
  - `--detect-network`  
  - `--network-filter`  
- **Database**: Tracks `network_name` and `network_ssid` (with auto-migration).  
- **Docs**: Added `MULTI_NETWORK.md` and updated README.  

### Quick Usage  

```powershell
# Copy template and configure
Copy-Item config.example.json config.json
```

```bash
# List & detect
python wifi_auto_login.py --list-networks
python wifi_auto_login.py --detect-network

# Login (auto or explicit profile)
python wifi_auto_login.py --login
python wifi_auto_login.py --login --network work

# View logs per network
python wifi_auto_login.py --view-logs 10 --network-filter work
```

---

Closes #8
